### PR TITLE
Fix bugs in CLI, service postgres queries

### DIFF
--- a/cmd/cli/VERSION
+++ b/cmd/cli/VERSION
@@ -1,6 +1,7 @@
-v0.1.2
-Increase timeout to 60 seconds when parsing go.mods
+v0.1.3
+Search for `go.sum`s rather than `go.mod`s
 
 Previously:
+* Increase timeout to 60 seconds when parsing go.mods
 * Fix bug when setting local Go modules
 * Initial release

--- a/cmd/cli/gomod.go
+++ b/cmd/cli/gomod.go
@@ -22,10 +22,9 @@ const (
 // BreakdownGoMod breaks down package file information
 func realBreakdownGoMod(modLoc string, ch chan<- *models.RepoPackageFile) error {
 	cfg := &packages.Config{
-		Tests:      true,
 		Mode:       pkgLoadMode,
 		Dir:        filepath.Dir(modLoc),
-		BuildFlags: []string{"-mod=readonly", "-tags", "tools"},
+		BuildFlags: []string{"-tags", "tools"},
 	}
 	pkgs, err := packages.Load(cfg, "./...", "./tools")
 	if err != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -47,7 +47,7 @@ func findFiles(root string) []string {
 				return filepath.SkipDir
 			}
 		}
-		if d.Name() == "go.mod" || d.Name() == "package.json" {
+		if d.Name() == "go.sum" || d.Name() == "package.json" {
 			files = append(files, path)
 		}
 		return nil
@@ -92,7 +92,7 @@ func main() {
 	for _, file := range findFiles(*dirFlag) {
 		fileC := file
 		switch filepath.Base(file) {
-		case "go.mod":
+		case "go.sum":
 			g.Go(func() error {
 				log.Printf("[GOMOD] processing %s", fileC)
 				if err := BreakdownGoMod(fileC, pkgChan); err != nil {

--- a/cmd/cli/npm.go
+++ b/cmd/cli/npm.go
@@ -242,6 +242,9 @@ func parseLockfileV2(mod *Module, lockfile LockfileV2) (*Module, error) {
 			name = pkgInfo.Name
 		}
 		nameVer := fmt.Sprintf("%s@%s", name, pkgInfo.Version)
+		if len(name) == 0 {
+			nameVer = "@"
+		}
 		pkg := &Pkg{
 			Name:     name,
 			Version:  pkgInfo.Version,

--- a/controller.go
+++ b/controller.go
@@ -29,7 +29,9 @@ func (mc MyController) beginTX(ctx context.Context) (pgx.Tx, *pgxpool.Conn, *db.
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	tx, err := conn.Begin(ctx)
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: pgx.Serializable,
+	})
 
 	if err != nil {
 		return nil, nil, nil, err

--- a/db/batch.go
+++ b/db/batch.go
@@ -15,9 +15,13 @@ import (
 const createDependency = `-- name: CreateDependency :batchmany
 WITH ins AS (
     INSERT INTO dependency (
-        name, version, type, is_local
-    ) VALUES (
+        id, name, version, type, is_local
+    ) SELECT
+        COALESCE(MAX(id), 0) + 1,
         $1, $2, $3, $4
+    FROM dependency
+    WHERE NOT EXISTS (
+        SELECT 1 FROM dependency WHERE name = $1 AND version = $2 AND type = $3
     )
     ON CONFLICT DO NOTHING
     RETURNING id, name, version, type, is_local
@@ -26,7 +30,7 @@ SELECT id, name, version, type, is_local FROM dependency d
 WHERE d.name = $1
     AND d.version = $2
     AND d.type = $3
-UNION
+UNION ALL
 SELECT id, name, version, type, is_local FROM ins
 `
 

--- a/db/queries.sql
+++ b/db/queries.sql
@@ -45,9 +45,13 @@ RETURNING id;
 -- name: CreateDependency :batchmany
 WITH ins AS (
     INSERT INTO dependency (
-        name, version, type, is_local
-    ) VALUES (
+        id, name, version, type, is_local
+    ) SELECT
+        COALESCE(MAX(id), 0) + 1,
         $1, $2, $3, $4
+    FROM dependency
+    WHERE NOT EXISTS (
+        SELECT 1 FROM dependency WHERE name = $1 AND version = $2 AND type = $3
     )
     ON CONFLICT DO NOTHING
     RETURNING *
@@ -56,7 +60,7 @@ SELECT * FROM dependency d
 WHERE d.name = $1
     AND d.version = $2
     AND d.type = $3
-UNION
+UNION ALL
 SELECT * FROM ins;
 
 -- name: GetDependencyId :one


### PR DESCRIPTION
## Link to JIRA:
None

## Overview:
* CLI bug fixes
  * Handle npm lockfile v1
  * Search for go.sums rather than go.mods
* Hardcode PK for inserting dependencies in breakdown service, prevents every-increasing PKs
* Set transaction mode

If you made any changes to swagger.yml:
- [n.a] Update swagger.yml version
- [n.a] Run "make generate"

## Testing
* Local testing

## Rollout

## Rollback (in the event of a problem)
- [ ] Rollback via dapple OR `ark rollback -e production breakdown`?
- [ ] Anything else?
