### PR TITLE
migrate apps to use mesh

### DIFF
--- a/launch/breakdown.yml
+++ b/launch/breakdown.yml
@@ -4,15 +4,15 @@ env:
 - POSTGRES_PASSWORD
 - POSTGRES_USERNAME
 resources:
-  cpu: 0.25
-  max_mem: 0.5
+  cpu: 0.5
+  max_mem: 1.0
 expose:
 - name: default
   port: 80
   health_check:
     type: http
     path: /_health
-team: 'eng-infra'
+team: eng-infra
 autoscaling:
   metric: cpu
   metric_target: 50
@@ -29,3 +29,5 @@ mesh_config:
     state: mesh_only
   crossRegionRoute: non-sso
   setupInternalRoute: true
+  prod:
+    state: hybrid


### PR DESCRIPTION
**Jira**
https://clever.atlassian.net/browse/INFRANG-5116

**Description**
These apps were missed during the migration or these apps were created and deployed after the migration was already started and before the tempalte repos were updated!

If this app is a worker then it is migrated to mesh_only. This is because hybrid is not a valid state for workers as they don't have an ALB

If this app is a service then it is migrated to hybrid. This means the app will ahve both ALB and envoy.

We also bump the cpu if the app has 0.25 cpu.

Let me know if you have any questions. I will be merging these PRs after hours today